### PR TITLE
impl Display for Argument

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -174,34 +174,6 @@ impl<'a> Argument<'a> {
 }
 
 impl Display for Argument<'_> {
-    /// Outputs a representation of the argument that approximates the original string.
-    ///
-    /// This function manually attempts to recreate the original string that was parsed into this
-    /// argument. It doesn't necessarily have to reflect the original, which is the case with
-    /// values like `--option=value` - the `=` will be lost.
-    ///
-    /// # Examples
-    ///
-    /// ```rust
-    /// use std::borrow::Cow;
-    /// use sap::Argument;
-    ///
-    /// // Long option
-    /// let arg = Argument::Long("foo");
-    /// assert_eq!(arg.to_string(), "--foo");
-    ///
-    /// // Short option
-    /// let arg = Argument::Short('o');
-    /// assert_eq!(arg.to_string(), "-o");
-    ///
-    /// // Value argument
-    /// let arg = Argument::Value(Cow::Borrowed("bar"));
-    /// assert_eq!(arg.to_string(), "bar");
-    ///
-    /// // Stdio argument
-    /// let arg = Argument::Stdio;
-    /// assert_eq!(arg.to_string(), "-");
-    /// ```
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         use Argument::{Long, Short, Stdio, Value};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -173,6 +173,47 @@ impl<'a> Argument<'a> {
     }
 }
 
+impl Display for Argument<'_> {
+    /// Outputs a representation of the argument that approximates the original string.
+    ///
+    /// This function manually attempts to recreate the original string that was parsed into this
+    /// argument. It doesn't necessarily have to reflect the original, which is the case with
+    /// values like `--option=value` - the `=` will be lost.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use std::borrow::Cow;
+    /// use sap::Argument;
+    ///
+    /// // Long option
+    /// let arg = Argument::Long("foo");
+    /// assert_eq!(arg.to_string(), "--foo");
+    ///
+    /// // Short option
+    /// let arg = Argument::Short('o');
+    /// assert_eq!(arg.to_string(), "-o");
+    ///
+    /// // Value argument
+    /// let arg = Argument::Value(Cow::Borrowed("bar"));
+    /// assert_eq!(arg.to_string(), "bar");
+    ///
+    /// // Stdio argument
+    /// let arg = Argument::Stdio;
+    /// assert_eq!(arg.to_string(), "-");
+    /// ```
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        use Argument::{Long, Short, Stdio, Value};
+
+        match self {
+            Long(s) => write!(f, "--{s}"),
+            Short(ch) => write!(f, "-{ch}"),
+            Value(cow) => write!(f, "{cow}"),
+            Stdio => write!(f, "-"),
+        }
+    }
+}
+
 /// A stateful command-line argument parser.
 ///
 /// The `Parser` processes arguments one at a time using an iterator-based approach,


### PR DESCRIPTION
:3c

this allows the user (me) to print errors like `unknown option: --foo`

:3c